### PR TITLE
Rename variable index

### DIFF
--- a/lib/batch_translations.rb
+++ b/lib/batch_translations.rb
@@ -6,13 +6,13 @@ module ActionView
         @locale_index ||= {}
 
         if @locale_index[locale].nil?
-          @index = @index ? @index + 1 : 1
-          @locale_index[locale] = @index
+          @i = @i ? @i + 1 : 1
+          @locale_index[locale] = @i
         else
-          @index = @locale_index[locale]
+          @i = @locale_index[locale]
         end
 
-        object_name = "#{@object_name}[translations_attributes][#{@index}]"
+        object_name = "#{@object_name}[translations_attributes][#{@i}]"
         object = @object.translations.select{|t| t.locale.to_s == locale.to_s}.first || @object.translations.find_by_locale(locale.to_s)
         @template.concat @template.hidden_field_tag("#{object_name}[id]", object ? object.id : "")
         @template.concat @template.hidden_field_tag("#{object_name}[locale]", locale)


### PR DESCRIPTION
fix error ActionView::Template::Error (no implicit conversion of Fixnum into String)

my environment:
$ rake about
About your application's environment
Rails version             4.2.1
Ruby version              2.1.5-p273 (x86_64-linux)
RubyGems version          2.4.6
Rack version              1.5
JavaScript Runtime        therubyracer (V8)
Middleware                Rack::Sendfile, ActionDispatch::Static, Rack::Lock, #ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x000000028c4428, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, RequestStore::Middleware, Rails::Rack::Logger, ActionDispatch::ShowExceptions, WebConsole::Middleware, ActionDispatch::DebugExceptions, ActionDispatch::RemoteIp, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActiveRecord::ConnectionAdapters::ConnectionManagement, ActiveRecord::QueryCache, ActionDispatch::Cookies, ActionDispatch::Session::ActiveRecordStore, ActionDispatch::Flash, ActionDispatch::ParamsParser, Rack::Head, Rack::ConditionalGet, Rack::ETag, SimplesIdeias::I18n::Middleware, ExceptionNotification::Rack, PDFKit::Middleware
Application root          /vagrant
Environment               development
Database adapter          mysql2
Database schema version   20150413150729
